### PR TITLE
Fabric abstraction

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -28,7 +28,7 @@ target_include_directories(core
 		${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 target_compile_options(core PRIVATE -Werror -Wall -Wextra -pedantic-errors)
-target_compile_features(core PUBLIC cxx_std_17)
+target_compile_features(core PUBLIC cxx_std_20)
 
 set_target_properties(core PROPERTIES
 	OUTPUT_NAME "marlin-core"
@@ -114,6 +114,7 @@ endforeach(TEST_SOURCE)
 ##########################################################
 
 set(EXAMPLE_SOURCES
+	examples/fabric.cpp
 )
 
 add_custom_target(core_examples)

--- a/core/examples/fabric.cpp
+++ b/core/examples/fabric.cpp
@@ -3,6 +3,11 @@
 
 using namespace marlin::core;
 
+
+size_t operator "" _sz (unsigned long long x) {
+  return x;
+}
+
 struct Empty {
 	template<typename... Args>
 	Empty(Args&&...) {}
@@ -35,11 +40,28 @@ struct Fiber {
 	}
 };
 
+
 int main() {
-	Fabric<Fiber<0>, Fabric<Fiber<1>, Fiber<2>>, Fiber<3>, Fiber<4>> f;
+	Fabric<
+		Fiber<Empty>,
+		Fiber,
+		Fiber,
+		FabricF<Fiber, Fiber>::type,
+		Fiber,
+		Fiber
+	> f(std::make_tuple(
+		// Fiber<Empty>
+		std::make_tuple(std::make_tuple(), 0_sz),
+		// Other fibers
+		std::make_tuple(5_sz),
+		std::make_tuple(6_sz),
+		std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz)),
+		std::make_tuple(3_sz),
+		std::make_tuple(4_sz)
+	));
 	// unique identity rule strikes again -_-
 	SPDLOG_INFO("{}", sizeof(f));
 
-	return f.did_recv(Fiber<0>(), Buffer(5));
+	return f.did_recv(0_sz, Buffer(5));
 }
 

--- a/core/examples/fabric.cpp
+++ b/core/examples/fabric.cpp
@@ -12,7 +12,7 @@ struct Fiber {
 };
 
 int main() {
-	Fabric<Fiber, Fiber, Fiber> f;
+	Fabric<Fiber, Fabric<Fiber, Fiber>, Fiber, Fiber> f;
 	(void)f;
 	return 0;
 }

--- a/core/examples/fabric.cpp
+++ b/core/examples/fabric.cpp
@@ -4,10 +4,6 @@
 using namespace marlin::core;
 
 
-size_t operator "" _sz (unsigned long long x) {
-  return x;
-}
-
 struct Terminal {
 	static constexpr bool is_outer_open = false;
 	static constexpr bool is_inner_open = false;
@@ -34,10 +30,10 @@ struct Fiber {
 	using OuterMessageType = Buffer;
 
 	[[no_unique_address]] ExtFabric ext_fabric;
-	size_t idx = 0;
+	int idx = 0;
 
 	template<typename ExtTupleType>
-	Fiber(std::tuple<ExtTupleType, size_t>&& init_tuple) :
+	Fiber(std::tuple<ExtTupleType, int>&& init_tuple) :
 		ext_fabric(std::get<0>(init_tuple)),
 		idx(std::get<1>(init_tuple)) {}
 
@@ -55,9 +51,9 @@ int main() {
 		Fiber
 	> f_simplest(std::make_tuple(
 		// Terminal
-		std::make_tuple(std::make_tuple(), 0_sz),
+		std::make_tuple(std::make_tuple(), 0),
 		// Other fibers
-		std::make_tuple(1_sz)
+		std::make_tuple(1)
 	));
 	f_simplest.did_recv(Buffer(5));
 
@@ -71,13 +67,13 @@ int main() {
 		Fiber
 	> f_multiple(std::make_tuple(
 		// Terminal
-		std::make_tuple(std::make_tuple(), 0_sz),
+		std::make_tuple(std::make_tuple(), 0),
 		// Other fibers
-		std::make_tuple(1_sz),
-		std::make_tuple(2_sz),
-		std::make_tuple(3_sz),
-		std::make_tuple(4_sz),
-		std::make_tuple(5_sz)
+		std::make_tuple(1),
+		std::make_tuple(2),
+		std::make_tuple(3),
+		std::make_tuple(4),
+		std::make_tuple(5)
 	));
 	f_multiple.did_recv(Buffer(5));
 
@@ -87,9 +83,9 @@ int main() {
 		FabricF<Fiber, Fiber>::type
 	> f_nested(std::make_tuple(
 		// Terminal
-		std::make_tuple(std::make_tuple(), 0_sz),
+		std::make_tuple(std::make_tuple(), 0),
 		// Other fibers
-		std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz))
+		std::make_tuple(std::make_tuple(1), std::make_tuple(2))
 	));
 	f_nested.did_recv(Buffer(5));
 
@@ -103,13 +99,13 @@ int main() {
 		FabricF<Fiber, Fiber>::type
 	> f_nested2(std::make_tuple(
 		// Terminal
-		std::make_tuple(std::make_tuple(), 0_sz),
+		std::make_tuple(std::make_tuple(), 0),
 		// Other fibers
-		std::make_tuple(1_sz),
-		std::make_tuple(2_sz),
-		std::make_tuple(3_sz),
-		std::make_tuple(4_sz),
-		std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz))
+		std::make_tuple(1),
+		std::make_tuple(2),
+		std::make_tuple(3),
+		std::make_tuple(4),
+		std::make_tuple(std::make_tuple(1), std::make_tuple(2))
 	));
 	f_nested2.did_recv(Buffer(5));
 
@@ -123,13 +119,13 @@ int main() {
 		Fiber
 	> f_nested3(std::make_tuple(
 		// Terminal
-		std::make_tuple(std::make_tuple(), 0_sz),
+		std::make_tuple(std::make_tuple(), 0),
 		// Other fibers
-		std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz)),
-		std::make_tuple(1_sz),
-		std::make_tuple(2_sz),
-		std::make_tuple(3_sz),
-		std::make_tuple(4_sz)
+		std::make_tuple(std::make_tuple(1), std::make_tuple(2)),
+		std::make_tuple(1),
+		std::make_tuple(2),
+		std::make_tuple(3),
+		std::make_tuple(4)
 	));
 	f_nested3.did_recv(Buffer(5));
 
@@ -143,13 +139,13 @@ int main() {
 		Fiber
 	> f_nested4(std::make_tuple(
 		// Terminal
-		std::make_tuple(std::make_tuple(), 0_sz),
+		std::make_tuple(std::make_tuple(), 0),
 		// Other fibers
-		std::make_tuple(1_sz),
-		std::make_tuple(2_sz),
-		std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz)),
-		std::make_tuple(3_sz),
-		std::make_tuple(4_sz)
+		std::make_tuple(1),
+		std::make_tuple(2),
+		std::make_tuple(std::make_tuple(1), std::make_tuple(2)),
+		std::make_tuple(3),
+		std::make_tuple(4)
 	));
 	f_nested4.did_recv(Buffer(5));
 
@@ -165,15 +161,15 @@ int main() {
 		Fiber
 	> f_nested5(std::make_tuple(
 		// Terminal
-		std::make_tuple(std::make_tuple(), 0_sz),
+		std::make_tuple(std::make_tuple(), 0),
 		// Other fibers
-		std::make_tuple(1_sz),
-		std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz)),
-		std::make_tuple(2_sz),
-		std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz)),
-		std::make_tuple(3_sz),
-		std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz)),
-		std::make_tuple(4_sz)
+		std::make_tuple(1),
+		std::make_tuple(std::make_tuple(1), std::make_tuple(2)),
+		std::make_tuple(2),
+		std::make_tuple(std::make_tuple(1), std::make_tuple(2)),
+		std::make_tuple(3),
+		std::make_tuple(std::make_tuple(1), std::make_tuple(2)),
+		std::make_tuple(4)
 	));
 	f_nested5.did_recv(Buffer(5));
 

--- a/core/examples/fabric.cpp
+++ b/core/examples/fabric.cpp
@@ -30,12 +30,12 @@ struct Fiber {
 		idx(std::get<1>(init_tuple)) {}
 
 	template<typename FabricType>
-	int did_recv(FabricType&& fabric, Buffer&& buf) {
+	int did_recv(FabricType&&, Buffer&& buf) {
 		SPDLOG_INFO("Did recv: {}", idx);
 		if constexpr (std::is_same_v<ExtFabric, Empty>) {
 			return 0;
 		} else {
-			return fabric.did_recv(*this, std::move(buf));
+			return ext_fabric.did_recv(*this, std::move(buf));
 		}
 	}
 };
@@ -87,46 +87,44 @@ int main() {
 	f_nested.did_recv(0_sz, Buffer(5));
 
 	// Nested fabric
-	// !!! Does not compile
-	//Fabric<
-		//Fiber<Empty>,
-		//Fiber,
-		//Fiber,
-		//Fiber,
-		//Fiber,
-		//FabricF<Fiber, Fiber>::type
-	//> f_nested2(std::make_tuple(
-		//// Fiber<Empty>
-		//std::make_tuple(std::make_tuple(), 0_sz),
-		//// Other fibers
-		//std::make_tuple(1_sz),
-		//std::make_tuple(2_sz),
-		//std::make_tuple(3_sz),
-		//std::make_tuple(4_sz),
-		//std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz))
-	//));
-	//f_nested2.did_recv(0_sz, Buffer(5));
+	Fabric<
+		Fiber<Empty>,
+		Fiber,
+		Fiber,
+		Fiber,
+		Fiber,
+		FabricF<Fiber, Fiber>::type
+	> f_nested2(std::make_tuple(
+		// Fiber<Empty>
+		std::make_tuple(std::make_tuple(), 0_sz),
+		// Other fibers
+		std::make_tuple(1_sz),
+		std::make_tuple(2_sz),
+		std::make_tuple(3_sz),
+		std::make_tuple(4_sz),
+		std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz))
+	));
+	f_nested2.did_recv(0_sz, Buffer(5));
 
 	// Nested fabric
-	// !!! Does not compile
-	//Fabric<
-		//Fiber<Empty>,
-		//FabricF<Fiber, Fiber>::type,
-		//Fiber,
-		//Fiber,
-		//Fiber,
-		//Fiber
-	//> f_nested3(std::make_tuple(
-		//// Fiber<Empty>
-		//std::make_tuple(std::make_tuple(), 0_sz),
-		//// Other fibers
-		//std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz)),
-		//std::make_tuple(1_sz),
-		//std::make_tuple(2_sz),
-		//std::make_tuple(3_sz),
-		//std::make_tuple(4_sz)
-	//));
-	//f_nested3.did_recv(0_sz, Buffer(5));
+	Fabric<
+		Fiber<Empty>,
+		FabricF<Fiber, Fiber>::type,
+		Fiber,
+		Fiber,
+		Fiber,
+		Fiber
+	> f_nested3(std::make_tuple(
+		// Fiber<Empty>
+		std::make_tuple(std::make_tuple(), 0_sz),
+		// Other fibers
+		std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz)),
+		std::make_tuple(1_sz),
+		std::make_tuple(2_sz),
+		std::make_tuple(3_sz),
+		std::make_tuple(4_sz)
+	));
+	f_nested3.did_recv(0_sz, Buffer(5));
 
 	// Nested fabric
 	Fabric<

--- a/core/examples/fabric.cpp
+++ b/core/examples/fabric.cpp
@@ -172,25 +172,6 @@ int main() {
 	));
 	f_nested5.did_recv(0_sz, Buffer(5));
 
-	Fabric<
-		Fiber<Empty>,
-		Fiber,
-		Fiber,
-		FabricF<Fiber, Fiber>::type,
-		Fiber,
-		Fiber
-	> f(std::make_tuple(
-		// Fiber<Empty>
-		std::make_tuple(std::make_tuple(), 0_sz),
-		// Other fibers
-		std::make_tuple(5_sz),
-		std::make_tuple(6_sz),
-		std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz)),
-		std::make_tuple(3_sz),
-		std::make_tuple(4_sz)
-	));
-	f.did_recv(0_sz, Buffer(5));
-
 	return 0;
 }
 

--- a/core/examples/fabric.cpp
+++ b/core/examples/fabric.cpp
@@ -1,0 +1,18 @@
+#include <marlin/core/fabric/Fabric.hpp>
+
+
+using namespace marlin::core;
+
+struct Fiber {
+	static constexpr bool is_outer_open = true;
+	static constexpr bool is_inner_open = true;
+
+	using InnerMessageType = int;
+	using OuterMessageType = int;
+};
+
+int main() {
+	Fabric<Fiber, Fiber, Fiber> f;
+	return 0;
+}
+

--- a/core/examples/fabric.cpp
+++ b/core/examples/fabric.cpp
@@ -3,18 +3,26 @@
 
 using namespace marlin::core;
 
+template<size_t idx = 0>
 struct Fiber {
 	static constexpr bool is_outer_open = true;
 	static constexpr bool is_inner_open = true;
 
 	using InnerMessageType = Buffer;
 	using OuterMessageType = Buffer;
+
+	template<typename FabricType>
+	int did_recv(FabricType&& fabric, Buffer&& buf) {
+		SPDLOG_INFO("Did recv: {}", idx);
+		return fabric.did_recv(*this, std::move(buf));
+	}
 };
 
 int main() {
-	Fabric<Fiber, Fabric<Fiber, Fiber>, Fiber, Fiber> f;
+	Fabric<Fiber<0>, Fabric<Fiber<1>, Fiber<2>>, Fiber<3>, Fiber<4>> f;
 	// unique identity rule strikes again -_-
 	SPDLOG_INFO("{}", sizeof(f));
-	return 0;
+
+	return f.did_recv(Fiber<0>(), Buffer(5));
 }
 

--- a/core/examples/fabric.cpp
+++ b/core/examples/fabric.cpp
@@ -18,8 +18,8 @@ struct Terminal {
 	template<typename... Args>
 	Terminal(Args&&...) {}
 
-	template<typename FabricType>
-	int did_recv(FabricType&&, Buffer&&) {
+	template<typename FiberType>
+	int did_recv(FiberType&, Buffer&&) {
 		SPDLOG_INFO("Did recv: Terminal");
 		return 0;
 	}
@@ -41,8 +41,7 @@ struct Fiber {
 		ext_fabric(std::get<0>(init_tuple)),
 		idx(std::get<1>(init_tuple)) {}
 
-	template<typename FabricType>
-	int did_recv(FabricType&&, Buffer&& buf) {
+	int did_recv(Buffer&& buf) {
 		SPDLOG_INFO("Did recv: {}", idx);
 		return ext_fabric.did_recv(*this, std::move(buf));
 	}
@@ -60,7 +59,7 @@ int main() {
 		// Other fibers
 		std::make_tuple(1_sz)
 	));
-	f_simplest.did_recv(0_sz, Buffer(5));
+	f_simplest.did_recv(Buffer(5));
 
 	// Multiple fibers fabric
 	Fabric<
@@ -80,7 +79,7 @@ int main() {
 		std::make_tuple(4_sz),
 		std::make_tuple(5_sz)
 	));
-	f_multiple.did_recv(0_sz, Buffer(5));
+	f_multiple.did_recv(Buffer(5));
 
 	// Nested fabric
 	Fabric<
@@ -92,7 +91,7 @@ int main() {
 		// Other fibers
 		std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz))
 	));
-	f_nested.did_recv(0_sz, Buffer(5));
+	f_nested.did_recv(Buffer(5));
 
 	// Nested fabric
 	Fabric<
@@ -112,7 +111,7 @@ int main() {
 		std::make_tuple(4_sz),
 		std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz))
 	));
-	f_nested2.did_recv(0_sz, Buffer(5));
+	f_nested2.did_recv(Buffer(5));
 
 	// Nested fabric
 	Fabric<
@@ -132,7 +131,7 @@ int main() {
 		std::make_tuple(3_sz),
 		std::make_tuple(4_sz)
 	));
-	f_nested3.did_recv(0_sz, Buffer(5));
+	f_nested3.did_recv(Buffer(5));
 
 	// Nested fabric
 	Fabric<
@@ -152,7 +151,7 @@ int main() {
 		std::make_tuple(3_sz),
 		std::make_tuple(4_sz)
 	));
-	f_nested4.did_recv(0_sz, Buffer(5));
+	f_nested4.did_recv(Buffer(5));
 
 	// Nested fabric
 	Fabric<
@@ -176,7 +175,7 @@ int main() {
 		std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz)),
 		std::make_tuple(4_sz)
 	));
-	f_nested5.did_recv(0_sz, Buffer(5));
+	f_nested5.did_recv(Buffer(5));
 
 	return 0;
 }

--- a/core/examples/fabric.cpp
+++ b/core/examples/fabric.cpp
@@ -42,6 +42,136 @@ struct Fiber {
 
 
 int main() {
+	// Simplest fabric
+	Fabric<
+		Fiber<Empty>,
+		Fiber
+	> f_simplest(std::make_tuple(
+		// Fiber<Empty>
+		std::make_tuple(std::make_tuple(), 0_sz),
+		// Other fibers
+		std::make_tuple(1_sz)
+	));
+	f_simplest.did_recv(0_sz, Buffer(5));
+
+	// Multiple fibers fabric
+	Fabric<
+		Fiber<Empty>,
+		Fiber,
+		Fiber,
+		Fiber,
+		Fiber,
+		Fiber
+	> f_multiple(std::make_tuple(
+		// Fiber<Empty>
+		std::make_tuple(std::make_tuple(), 0_sz),
+		// Other fibers
+		std::make_tuple(1_sz),
+		std::make_tuple(2_sz),
+		std::make_tuple(3_sz),
+		std::make_tuple(4_sz),
+		std::make_tuple(5_sz)
+	));
+	f_multiple.did_recv(0_sz, Buffer(5));
+
+	// Nested fabric
+	Fabric<
+		Fiber<Empty>,
+		FabricF<Fiber, Fiber>::type
+	> f_nested(std::make_tuple(
+		// Fiber<Empty>
+		std::make_tuple(std::make_tuple(), 0_sz),
+		// Other fibers
+		std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz))
+	));
+	f_nested.did_recv(0_sz, Buffer(5));
+
+	// Nested fabric
+	// !!! Does not compile
+	//Fabric<
+		//Fiber<Empty>,
+		//Fiber,
+		//Fiber,
+		//Fiber,
+		//Fiber,
+		//FabricF<Fiber, Fiber>::type
+	//> f_nested2(std::make_tuple(
+		//// Fiber<Empty>
+		//std::make_tuple(std::make_tuple(), 0_sz),
+		//// Other fibers
+		//std::make_tuple(1_sz),
+		//std::make_tuple(2_sz),
+		//std::make_tuple(3_sz),
+		//std::make_tuple(4_sz),
+		//std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz))
+	//));
+	//f_nested2.did_recv(0_sz, Buffer(5));
+
+	// Nested fabric
+	// !!! Does not compile
+	//Fabric<
+		//Fiber<Empty>,
+		//FabricF<Fiber, Fiber>::type,
+		//Fiber,
+		//Fiber,
+		//Fiber,
+		//Fiber
+	//> f_nested3(std::make_tuple(
+		//// Fiber<Empty>
+		//std::make_tuple(std::make_tuple(), 0_sz),
+		//// Other fibers
+		//std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz)),
+		//std::make_tuple(1_sz),
+		//std::make_tuple(2_sz),
+		//std::make_tuple(3_sz),
+		//std::make_tuple(4_sz)
+	//));
+	//f_nested3.did_recv(0_sz, Buffer(5));
+
+	// Nested fabric
+	Fabric<
+		Fiber<Empty>,
+		Fiber,
+		Fiber,
+		FabricF<Fiber, Fiber>::type,
+		Fiber,
+		Fiber
+	> f_nested4(std::make_tuple(
+		// Fiber<Empty>
+		std::make_tuple(std::make_tuple(), 0_sz),
+		// Other fibers
+		std::make_tuple(1_sz),
+		std::make_tuple(2_sz),
+		std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz)),
+		std::make_tuple(3_sz),
+		std::make_tuple(4_sz)
+	));
+	f_nested4.did_recv(0_sz, Buffer(5));
+
+	// Nested fabric
+	Fabric<
+		Fiber<Empty>,
+		Fiber,
+		FabricF<Fiber, Fiber>::type,
+		Fiber,
+		FabricF<Fiber, Fiber>::type,
+		Fiber,
+		FabricF<Fiber, Fiber>::type,
+		Fiber
+	> f_nested5(std::make_tuple(
+		// Fiber<Empty>
+		std::make_tuple(std::make_tuple(), 0_sz),
+		// Other fibers
+		std::make_tuple(1_sz),
+		std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz)),
+		std::make_tuple(2_sz),
+		std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz)),
+		std::make_tuple(3_sz),
+		std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz)),
+		std::make_tuple(4_sz)
+	));
+	f_nested5.did_recv(0_sz, Buffer(5));
+
 	Fabric<
 		Fiber<Empty>,
 		Fiber,
@@ -59,9 +189,8 @@ int main() {
 		std::make_tuple(3_sz),
 		std::make_tuple(4_sz)
 	));
-	// unique identity rule strikes again -_-
-	SPDLOG_INFO("{}", sizeof(f));
+	f.did_recv(0_sz, Buffer(5));
 
-	return f.did_recv(0_sz, Buffer(5));
+	return 0;
 }
 

--- a/core/examples/fabric.cpp
+++ b/core/examples/fabric.cpp
@@ -3,13 +3,21 @@
 
 using namespace marlin::core;
 
-template<size_t idx = 0>
+template<typename ExtFabric>
 struct Fiber {
 	static constexpr bool is_outer_open = true;
 	static constexpr bool is_inner_open = true;
 
 	using InnerMessageType = Buffer;
 	using OuterMessageType = Buffer;
+
+	[[no_unique_address]] ExtFabric ext_fabric;
+	size_t idx = 0;
+
+	template<typename ExtTupleType>
+	Fiber(std::tuple<ExtTupleType, size_t>&& init_tuple) :
+		ext_fabric(std::get<0>(init_tuple)),
+		idx(std::get<1>(init_tuple)) {}
 
 	template<typename FabricType>
 	int did_recv(FabricType&& fabric, Buffer&& buf) {

--- a/core/examples/fabric.cpp
+++ b/core/examples/fabric.cpp
@@ -3,6 +3,11 @@
 
 using namespace marlin::core;
 
+struct Empty {
+	template<typename... Args>
+	Empty(Args&&...) {}
+};
+
 template<typename ExtFabric>
 struct Fiber {
 	static constexpr bool is_outer_open = true;
@@ -22,7 +27,11 @@ struct Fiber {
 	template<typename FabricType>
 	int did_recv(FabricType&& fabric, Buffer&& buf) {
 		SPDLOG_INFO("Did recv: {}", idx);
-		return fabric.did_recv(*this, std::move(buf));
+		if constexpr (std::is_same_v<ExtFabric, Empty>) {
+			return 0;
+		} else {
+			return fabric.did_recv(*this, std::move(buf));
+		}
 	}
 };
 

--- a/core/examples/fabric.cpp
+++ b/core/examples/fabric.cpp
@@ -8,9 +8,21 @@ size_t operator "" _sz (unsigned long long x) {
   return x;
 }
 
-struct Empty {
+struct Terminal {
+	static constexpr bool is_outer_open = false;
+	static constexpr bool is_inner_open = false;
+
+	using InnerMessageType = Buffer;
+	using OuterMessageType = Buffer;
+
 	template<typename... Args>
-	Empty(Args&&...) {}
+	Terminal(Args&&...) {}
+
+	template<typename FabricType>
+	int did_recv(FabricType&&, Buffer&&) {
+		SPDLOG_INFO("Did recv: Terminal");
+		return 0;
+	}
 };
 
 template<typename ExtFabric>
@@ -32,11 +44,7 @@ struct Fiber {
 	template<typename FabricType>
 	int did_recv(FabricType&&, Buffer&& buf) {
 		SPDLOG_INFO("Did recv: {}", idx);
-		if constexpr (std::is_same_v<ExtFabric, Empty>) {
-			return 0;
-		} else {
-			return ext_fabric.did_recv(*this, std::move(buf));
-		}
+		return ext_fabric.did_recv(*this, std::move(buf));
 	}
 };
 
@@ -44,10 +52,10 @@ struct Fiber {
 int main() {
 	// Simplest fabric
 	Fabric<
-		Fiber<Empty>,
+		Terminal,
 		Fiber
 	> f_simplest(std::make_tuple(
-		// Fiber<Empty>
+		// Terminal
 		std::make_tuple(std::make_tuple(), 0_sz),
 		// Other fibers
 		std::make_tuple(1_sz)
@@ -56,14 +64,14 @@ int main() {
 
 	// Multiple fibers fabric
 	Fabric<
-		Fiber<Empty>,
+		Terminal,
 		Fiber,
 		Fiber,
 		Fiber,
 		Fiber,
 		Fiber
 	> f_multiple(std::make_tuple(
-		// Fiber<Empty>
+		// Terminal
 		std::make_tuple(std::make_tuple(), 0_sz),
 		// Other fibers
 		std::make_tuple(1_sz),
@@ -76,10 +84,10 @@ int main() {
 
 	// Nested fabric
 	Fabric<
-		Fiber<Empty>,
+		Terminal,
 		FabricF<Fiber, Fiber>::type
 	> f_nested(std::make_tuple(
-		// Fiber<Empty>
+		// Terminal
 		std::make_tuple(std::make_tuple(), 0_sz),
 		// Other fibers
 		std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz))
@@ -88,14 +96,14 @@ int main() {
 
 	// Nested fabric
 	Fabric<
-		Fiber<Empty>,
+		Terminal,
 		Fiber,
 		Fiber,
 		Fiber,
 		Fiber,
 		FabricF<Fiber, Fiber>::type
 	> f_nested2(std::make_tuple(
-		// Fiber<Empty>
+		// Terminal
 		std::make_tuple(std::make_tuple(), 0_sz),
 		// Other fibers
 		std::make_tuple(1_sz),
@@ -108,14 +116,14 @@ int main() {
 
 	// Nested fabric
 	Fabric<
-		Fiber<Empty>,
+		Terminal,
 		FabricF<Fiber, Fiber>::type,
 		Fiber,
 		Fiber,
 		Fiber,
 		Fiber
 	> f_nested3(std::make_tuple(
-		// Fiber<Empty>
+		// Terminal
 		std::make_tuple(std::make_tuple(), 0_sz),
 		// Other fibers
 		std::make_tuple(std::make_tuple(1_sz), std::make_tuple(2_sz)),
@@ -128,14 +136,14 @@ int main() {
 
 	// Nested fabric
 	Fabric<
-		Fiber<Empty>,
+		Terminal,
 		Fiber,
 		Fiber,
 		FabricF<Fiber, Fiber>::type,
 		Fiber,
 		Fiber
 	> f_nested4(std::make_tuple(
-		// Fiber<Empty>
+		// Terminal
 		std::make_tuple(std::make_tuple(), 0_sz),
 		// Other fibers
 		std::make_tuple(1_sz),
@@ -148,7 +156,7 @@ int main() {
 
 	// Nested fabric
 	Fabric<
-		Fiber<Empty>,
+		Terminal,
 		Fiber,
 		FabricF<Fiber, Fiber>::type,
 		Fiber,
@@ -157,7 +165,7 @@ int main() {
 		FabricF<Fiber, Fiber>::type,
 		Fiber
 	> f_nested5(std::make_tuple(
-		// Fiber<Empty>
+		// Terminal
 		std::make_tuple(std::make_tuple(), 0_sz),
 		// Other fibers
 		std::make_tuple(1_sz),

--- a/core/examples/fabric.cpp
+++ b/core/examples/fabric.cpp
@@ -13,6 +13,7 @@ struct Fiber {
 
 int main() {
 	Fabric<Fiber, Fiber, Fiber> f;
+	(void)f;
 	return 0;
 }
 

--- a/core/examples/fabric.cpp
+++ b/core/examples/fabric.cpp
@@ -1,5 +1,5 @@
 #include <marlin/core/fabric/Fabric.hpp>
-
+#include <spdlog/spdlog.h>
 
 using namespace marlin::core;
 
@@ -7,13 +7,14 @@ struct Fiber {
 	static constexpr bool is_outer_open = true;
 	static constexpr bool is_inner_open = true;
 
-	using InnerMessageType = int;
-	using OuterMessageType = int;
+	using InnerMessageType = Buffer;
+	using OuterMessageType = Buffer;
 };
 
 int main() {
 	Fabric<Fiber, Fabric<Fiber, Fiber>, Fiber, Fiber> f;
-	(void)f;
+	// unique identity rule strikes again -_-
+	SPDLOG_INFO("{}", sizeof(f));
 	return 0;
 }
 

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -7,6 +7,20 @@
 namespace marlin {
 namespace core {
 
+template<size_t idx, template<typename> typename FiberTemplate, template<typename> typename... FiberTemplates>
+	requires (idx != 0)
+struct NthFiberHelper {
+	template<typename T>
+	using type = typename NthFiberHelper<idx-1, FiberTemplates...>::template type<T>;
+};
+
+template<template<typename> typename FiberTemplate, template<typename> typename... FiberTemplates>
+struct NthFiberHelper<1, FiberTemplate, FiberTemplates...> {
+	template<typename T>
+	using type = FiberTemplate<T>;
+};
+
+
 // Fibers assumed to be ordered from Outer to Inner
 template<typename ExtFabric, template<typename> typename... FiberTemplates>
 class Fabric {

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -11,7 +11,7 @@ namespace core {
 template<typename ExtFabric, template<typename> typename... FiberTemplates>
 class Fabric {
 public:
-	using SelfType = Fabric<ExtFabric, Fibers...>;
+	using SelfType = Fabric<ExtFabric, FiberTemplates...>;
 private:
 	struct Empty {};
 

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -71,11 +71,11 @@ private:
 			if constexpr (idx == sizeof...(Fibers)) {
 				// inside shuttle of last fiber, exit
 				return fabric.ext_fabric.did_recv(fabric, std::forward<Args>(args)...);
+			} else {
+				// Transition to next fiber
+				auto& next_fiber = std::get<idx>(fabric.fibers);
+				return next_fiber.did_recv(Shuttle<idx+1>(), std::forward<Args>(args)...);
 			}
-
-			// Transition to next fiber
-			auto& next_fiber = std::get<idx>(fabric.fibers);
-			return next_fiber.did_recv(Shuttle<idx+1>(), std::forward<Args>(args)...);
 		}
 	};
 

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -57,9 +57,9 @@ public:
 			// Should never have idx 0
 			idx != 0 &&
 			// Should never be called with idx 1 if outermost fiber is closed on the outer side
-			!(idx == 1 && NthFiber<1>::is_outer_open == false)
+			!(idx == 1 && !NthFiber<1>::is_outer_open)
 		)
-	int did_recv(FabricType&&, core::Buffer&&, Args&&...) {
+	int did_recv(FabricType&&, Buffer&&, Args&&...) {
 		return 0;
 	}
 };

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -81,11 +81,15 @@ private:
 	// Assert that all fibers fit well together
 	static_assert(fits(std::make_index_sequence<sizeof...(FiberTemplates)-1>{}));
 
-	// Important: Not zero indexed!
-	[[no_unique_address]] std::tuple<Empty, Fibers...> fibers;
-
 	// External fabric
 	[[no_unique_address]] ExtFabric ext_fabric;
+
+	// Important: Not zero indexed!
+	[[no_unique_address]] TupleHelper<
+		sizeof...(FiberTemplates),
+		Shuttle,
+		FiberTemplates...
+	> fibers;
 
 	// Warning: Potentially very brittle
 	// Calculate offset of fabric from reference to fiber

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -29,6 +29,20 @@ struct TupleCat<T, std::tuple<TupleTypes...>> {
 	using type = std::tuple<TupleTypes..., T>;
 };
 
+template<size_t idx, template<size_t> typename Shuttle, template<typename> typename FiberTemplate, template<typename> typename... FiberTemplates>
+	requires (idx != 0)
+struct TupleHelper {
+	using base = typename TupleHelper<idx-1, Shuttle, FiberTemplates...>::type;
+	using type = typename TupleCat<FiberTemplate<Shuttle<idx>>, base>::type;
+};
+
+template<template<size_t> typename Shuttle, template<typename> typename FiberTemplate, template<typename> typename... FiberTemplates>
+struct TupleHelper<1, Shuttle, FiberTemplate, FiberTemplates...> {
+	struct Empty {};
+	using type = std::tuple<Empty, FiberTemplate<Shuttle<1>>>;
+};
+
+
 // Fibers assumed to be ordered from Outer to Inner
 template<typename ExtFabric, template<typename> typename... FiberTemplates>
 class Fabric {

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -109,6 +109,9 @@ private:
 	template<size_t idx>
 	struct Shuttle {
 		template<typename... Args>
+		Shuttle(Args&&...) {}
+
+		template<typename... Args>
 		int did_recv(NthFiber<idx>& caller, Args&&... args) {
 			// Warning: Requires that caller is fiber at idx
 			auto& fabric = get_fabric<idx>(caller);

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -102,8 +102,8 @@ public:
 			// Should never call external fabric if innermost fiber is closed on the inner side
 			!(idx == sizeof...(Fibers) + 1 && !NthFiber<sizeof...(Fibers)>::is_inner_open)
 		)
-	int did_recv(FabricType&&, typename NthFiber<idx>::OuterMessageType&&, Args&&...) {
-		return 0;
+	int did_recv(FabricType&&, typename NthFiber<idx>::OuterMessageType&& buf, Args&&... args) {
+		return std::get<idx>(fibers).did_recv(Shuttle<idx>(), std::move(buf), std::forward<Args>(args)...);
 	}
 };
 

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -8,6 +8,11 @@ namespace core {
 template<typename... Fibers>
 class Fabric {
 
+	// Important: Not zero indexed!
+	template<int n>
+		requires (n <= sizeof...(Fibers))
+	using NthFiber = typename std::tuple_element<n, std::tuple<void, Fibers...>>::type;
+
 private:
 	// Important: Not zero indexed!
 	std::tuple<void, Fibers...> fibers;

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -38,7 +38,10 @@ struct TupleHelper {
 
 template<template<size_t> typename Shuttle, template<typename> typename FiberTemplate, template<typename> typename... FiberTemplates>
 struct TupleHelper<1, Shuttle, FiberTemplate, FiberTemplates...> {
-	struct Empty {};
+	struct Empty {
+		template<typename... Args>
+		Empty(Args&&...) {}
+	};
 	using type = std::tuple<Empty, FiberTemplate<Shuttle<1>>>;
 };
 

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -160,7 +160,7 @@ private:
 			} else {
 				// Transition to next fiber
 				auto& next_fiber = std::get<idx+1>(fabric.fibers);
-				return next_fiber.did_recv(Shuttle<idx+1>(), std::forward<Args>(args)...);
+				return next_fiber.did_recv(std::forward<Args>(args)...);
 			}
 		}
 	};
@@ -177,14 +177,14 @@ public:
 	// [1,len(Fibers)]			call on fiber
 	// len(Fibers)+1			call on external fabric
 
-	template<typename FabricType, typename... Args>
+	template<typename... Args>
 		requires (
 			// Should only be called if outermost fiber is
 			// open on the outer side
 			NthFiber<1>::is_outer_open
 		)
-	int did_recv(FabricType&&, typename NthFiber<1>::OuterMessageType&& buf, Args&&... args) {
-		return std::get<1>(fibers).did_recv(Shuttle<1>(), std::move(buf), std::forward<Args>(args)...);
+	int did_recv(typename NthFiber<1>::OuterMessageType&& buf, Args&&... args) {
+		return std::get<1>(fibers).did_recv(std::move(buf), std::forward<Args>(args)...);
 	}
 };
 

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -11,7 +11,7 @@ namespace core {
 template<typename ExtFabric, typename... Fibers>
 class Fabric {
 public:
-	using SelfType = Fabric<ExtFabric, Fibers...>
+	using SelfType = Fabric<ExtFabric, Fibers...>;
 private:
 	struct Empty {};
 

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -21,6 +21,14 @@ struct NthFiberHelper<1, FiberTemplate, FiberTemplates...> {
 };
 
 
+template<typename T, typename Tuple>
+struct TupleCat {};
+
+template<typename T, typename... TupleTypes>
+struct TupleCat<T, std::tuple<TupleTypes...>> {
+	using type = std::tuple<TupleTypes..., T>;
+};
+
 // Fibers assumed to be ordered from Outer to Inner
 template<typename ExtFabric, template<typename> typename... FiberTemplates>
 class Fabric {

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -93,6 +93,32 @@ private:
 		FiberTemplates...
 	>::type fibers;
 
+
+	// Private constructor
+	template<typename ExtTupleType, typename... TupleTypes, size_t... Is>
+	Fabric(std::tuple<ExtTupleType, TupleTypes...>&& init_tuple, std::index_sequence<Is...>) :
+		ext_fabric(std::move(std::get<0>(init_tuple))),
+		fibers(
+			// Empty
+			std::make_tuple(),
+			// Other fibers
+			std::move(std::tuple_cat(
+				// Shuttle
+				std::make_tuple(std::make_tuple()),
+				// Init
+				std::move(std::get<Is+1>(init_tuple))
+			))...
+		)
+	{}
+
+public:
+	// Public constructor
+	template<typename ExtTupleType, typename... TupleTypes>
+	Fabric(std::tuple<ExtTupleType, TupleTypes...>&& init_tuple) :
+		Fabric(std::move(init_tuple), std::index_sequence_for<TupleTypes...>())
+	{}
+
+private:
 	// Warning: Potentially very brittle
 	// Calculate offset of fabric from reference to fiber
 	template<size_t idx>

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -8,8 +8,11 @@ namespace marlin {
 namespace core {
 
 // Fibers assumed to be ordered from Outer to Inner
-template<typename... Fibers>
+template<typename ExtFabric, typename... Fibers>
 class Fabric {
+public:
+	using SelfType = Fabric<ExtFabric, Fibers...>
+private:
 	struct Empty {};
 
 	// Important: Not zero indexed!
@@ -38,9 +41,12 @@ class Fabric {
 	// Assert that all fibers fit well together
 	static_assert(fits(std::make_index_sequence<sizeof...(Fibers)-1>{}));
 
-private:
 	// Important: Not zero indexed!
-	std::tuple<Empty, Fibers...> fibers;
+	[[no_unique_address]] std::tuple<Empty, Fibers...> fibers;
+
+	// External fabric
+	[[no_unique_address]] ExtFabric ext_fabric;
+
 public:
 	using OuterMessageType = typename NthFiber<1>::OuterMessageType;
 	using InnerMessageType = typename NthFiber<sizeof...(Fibers)>::InnerMessageType;

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -30,9 +30,9 @@ private:
 	struct Empty {};
 
 	// Important: Not zero indexed!
-	template<size_t n>
-		//requires (n <= sizeof...(Fibers))
-	using NthFiber = typename std::tuple_element<n, std::tuple<Empty, Fibers...>>::type;
+	template<size_t idx>
+		//requires (idx <= sizeof...(Fibers))
+	using NthFiber = typename NthFiberHelper<idx, FiberTemplates...>::template type<Shuttle<idx>>;
 
 	template<typename FiberOuter, typename FiberInner>
 	static constexpr bool fits_binary() {

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -7,6 +7,8 @@
 namespace marlin {
 namespace core {
 
+namespace {
+
 template<size_t idx, template<typename> typename FiberTemplate, template<typename> typename... FiberTemplates>
 	requires (idx != 0)
 struct NthFiberHelper {
@@ -50,6 +52,7 @@ struct TupleHelper<idx, idx, Shuttle, FiberTemplate, FiberTemplates...> {
 	using type = std::tuple<FiberTemplate<Shuttle<idx>>>;
 };
 
+}
 
 // Fibers assumed to be ordered from Outer to Inner
 template<typename ExtFabric, template<typename> typename... FiberTemplates>

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -60,7 +60,9 @@ public:
 			// Should never have idx 0
 			idx != 0 &&
 			// Should never be called with idx 1 if outermost fiber is closed on the outer side
-			!(idx == 1 && !NthFiber<1>::is_outer_open)
+			!(idx == 1 && !NthFiber<1>::is_outer_open) &&
+			// Should never call external fabric if innermost fiber is closed on the inner side
+			!(idx == sizeof...(Fibers) + 1 && !NthFiber<sizeof...(Fibers)>::is_inner_open)
 		)
 	int did_recv(FabricType&&, Buffer&&, Args&&...) {
 		return 0;

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -174,22 +174,14 @@ public:
 	// [1,len(Fibers)]			call on fiber
 	// len(Fibers)+1			call on external fabric
 
-	template<typename FabricType, typename... Args, size_t idx = 1>
+	template<typename FabricType, typename... Args>
 		requires (
-			// idx should be in range
-			idx <= sizeof...(FiberTemplates) + 1 &&
-			// Should never have idx 0
-			idx != 0 &&
-			// Should never be called with idx 1 if outermost fiber is closed on the outer side
-			!(idx == 1 && !NthFiber<1>::is_outer_open) &&
-			// Should never call external fabric if innermost fiber is closed on the inner side
-			!(
-				idx == sizeof...(FiberTemplates) + 1 &&
-				!NthFiber<sizeof...(FiberTemplates)>::is_inner_open
-			)
+			// Should only be called if outermost fiber is
+			// open on the outer side
+			NthFiber<1>::is_outer_open
 		)
-	int did_recv(FabricType&&, typename NthFiber<idx>::OuterMessageType&& buf, Args&&... args) {
-		return std::get<idx>(fibers).did_recv(Shuttle<idx>(), std::move(buf), std::forward<Args>(args)...);
+	int did_recv(FabricType&&, typename NthFiber<1>::OuterMessageType&& buf, Args&&... args) {
+		return std::get<1>(fibers).did_recv(Shuttle<1>(), std::move(buf), std::forward<Args>(args)...);
 	}
 };
 

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -40,6 +40,11 @@ private:
 public:
 	using OuterMessageType = decltype(std::get<0>(stages))::OuterMessageType;
 	using InnerMessageType = decltype(std::get<sizeof...(Fibers) - 1>(fibers))::InnerMessageType;
+
+	template<typename FabricType, typename... Args, size_t idx = 1>
+	int did_recv(FabricType&&, core::Buffer&&, Args&&...) {
+		return 0;
+	}
 };
 
 }  // namespace core

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -51,9 +51,8 @@ template<typename ExtFabric, template<typename> typename... FiberTemplates>
 class Fabric {
 public:
 	using SelfType = Fabric<ExtFabric, FiberTemplates...>;
-private:
-	struct Empty {};
 
+private:
 	// Forward declaration
 	template<size_t idx>
 	struct Shuttle;

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -13,6 +13,27 @@ class Fabric {
 		requires (n <= sizeof...(Fibers))
 	using NthFiber = typename std::tuple_element<n, std::tuple<void, Fibers...>>::type;
 
+	template<typename FiberOuter, typename FiberInner>
+	static constexpr bool fits() {
+		return (
+			// Outer fiber must be open on the inner side
+			FiberOuter::is_inner_open &&
+			// Inner fiber must be open on the outer side
+			FiberInner::is_outer_open &&
+			// MessageType must be compatible
+			std::is_same_v<FiberOuter::InnerMessageType, FiberInner::OuterMessageType>
+		);
+	}
+
+	template<size_t... Is>
+	static constexpr bool fits(std::index_sequence<Is...>) {
+		// fold expression
+		return ... && (Is == 0 || fits<NthFiber<Is>, NthFiber<Is+1>>());
+	}
+
+	// Assert that all fibers fit well together
+	static_assert(fits(std::index_sequence_for<Is...>);
+
 private:
 	// Important: Not zero indexed!
 	std::tuple<void, Fibers...> fibers;

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -29,6 +29,10 @@ public:
 private:
 	struct Empty {};
 
+	// Forward declaration
+	template<size_t idx>
+	struct Shuttle;
+
 	// Important: Not zero indexed!
 	template<size_t idx>
 		//requires (idx <= sizeof...(Fibers))

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -57,7 +57,7 @@ private:
 	}
 
 	// Assert that all fibers fit well together
-	static_assert(fits(std::make_index_sequence<sizeof...(Fibers)-1>{}));
+	static_assert(fits(std::make_index_sequence<sizeof...(FiberTemplates)-1>{}));
 
 	// Important: Not zero indexed!
 	[[no_unique_address]] std::tuple<Empty, Fibers...> fibers;

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -64,7 +64,7 @@ public:
 			// Should never call external fabric if innermost fiber is closed on the inner side
 			!(idx == sizeof...(Fibers) + 1 && !NthFiber<sizeof...(Fibers)>::is_inner_open)
 		)
-	int did_recv(FabricType&&, Buffer&&, Args&&...) {
+	int did_recv(FabricType&&, typename NthFiber<idx>::OuterMessageType&&, Args&&...) {
 		return 0;
 	}
 };

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -8,7 +8,7 @@ namespace marlin {
 namespace core {
 
 // Fibers assumed to be ordered from Outer to Inner
-template<typename ExtFabric, typename... Fibers>
+template<typename ExtFabric, template<typename> typename... FiberTemplates>
 class Fabric {
 public:
 	using SelfType = Fabric<ExtFabric, Fibers...>;

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -154,6 +154,13 @@ public:
 	}
 };
 
+
+template<template<typename> typename... F>
+struct FabricF {
+	template<typename T>
+	using type = Fabric<T, F...>;
+};
+
 }  // namespace core
 }  // namespace marlin
 

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -85,11 +85,11 @@ private:
 	[[no_unique_address]] ExtFabric ext_fabric;
 
 	// Important: Not zero indexed!
-	[[no_unique_address]] TupleHelper<
+	[[no_unique_address]] typename TupleHelper<
 		sizeof...(FiberTemplates),
 		Shuttle,
 		FiberTemplates...
-	> fibers;
+	>::type fibers;
 
 	// Warning: Potentially very brittle
 	// Calculate offset of fabric from reference to fiber

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -45,6 +45,9 @@ public:
 	using OuterMessageType = typename NthFiber<1>::OuterMessageType;
 	using InnerMessageType = typename NthFiber<sizeof...(Fibers)>::InnerMessageType;
 
+	static constexpr bool is_outer_open = NthFiber<1>::is_outer_open;
+	static constexpr bool is_inner_open = NthFiber<sizeof...(Fibers)>::is_inner_open;
+
 	// Guide to fiber index
 	// 0						call on external fabric
 	// [1,len(Fibers)]			call on fiber

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -117,7 +117,7 @@ private:
 				return fabric.ext_fabric.did_recv(fabric, std::forward<Args>(args)...);
 			} else {
 				// Transition to next fiber
-				auto& next_fiber = std::get<idx>(fabric.fibers);
+				auto& next_fiber = std::get<idx+1>(fabric.fibers);
 				return next_fiber.did_recv(Shuttle<idx+1>(), std::forward<Args>(args)...);
 			}
 		}

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -4,12 +4,16 @@
 namespace marlin {
 namespace core {
 
+// Fibers assumed to be ordered from Outer to Inner
 template<typename... Fibers>
 class Fabric {
 
 private:
 	// Important: Not zero indexed!
 	std::tuple<void, Fibers...> fibers;
+public:
+	using OuterMessageType = decltype(std::get<0>(stages))::OuterMessageType;
+	using InnerMessageType = decltype(std::get<sizeof...(Fibers) - 1>(fibers))::InnerMessageType;
 };
 
 }  // namespace core

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -1,0 +1,18 @@
+#ifndef MARLIN_CORE_FABRIC_FABRIC_HPP
+#define MARLIN_CORE_FABRIC_FABRIC_HPP
+
+namespace marlin {
+namespace core {
+
+template<typename... Fibers>
+class Fabric {
+
+private:
+	// Important: Not zero indexed!
+	std::tuple<void, Fibers...> fibers;
+};
+
+}  // namespace core
+}  // namespace marlin
+
+#endif  // MARLIN_CORE_FABRIC_FABRIC_HPP

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -41,7 +41,20 @@ public:
 	using OuterMessageType = decltype(std::get<0>(stages))::OuterMessageType;
 	using InnerMessageType = decltype(std::get<sizeof...(Fibers) - 1>(fibers))::InnerMessageType;
 
+	// Guide to fiber index
+	// 0						call on external fabric
+	// [1,len(Fibers)]			call on fiber
+	// len(Fibers)+1			call on external fabric
+
 	template<typename FabricType, typename... Args, size_t idx = 1>
+		requires (
+			// idx should be in range
+			idx <= sizeof...(Fibers) + 1 &&
+			// Should never have idx 0
+			idx != 0 &&
+			// Should never be called with idx 1 if outermost fiber is closed on the outer side
+			!(idx == 1 && NthFiber<1>::is_outer_open == false)
+		)
 	int did_recv(FabricType&&, core::Buffer&&, Args&&...) {
 		return 0;
 	}

--- a/core/include/marlin/core/fabric/Fabric.hpp
+++ b/core/include/marlin/core/fabric/Fabric.hpp
@@ -47,6 +47,18 @@ private:
 	// External fabric
 	[[no_unique_address]] ExtFabric ext_fabric;
 
+	// Warning: Potentially very brittle
+	// Calculate offset of fabric from reference to fiber
+	template<size_t idx>
+	static constexpr SelfType& get_fabric(NthFiber<idx>& fiber_ptr) {
+		// Type cast from nullptr
+		// Other option is to declare local var, but forces default constructible
+		auto* ref_fabric_ptr = (SelfType*)nullptr;
+		auto* ref_fiber_ptr = &std::get<idx>(ref_fabric_ptr->fibers);
+
+		return *(SelfType*)((uint8_t*)&fiber_ptr - ((uint8_t*)ref_fiber_ptr - (uint8_t*)ref_fabric_ptr));
+	}
+
 public:
 	using OuterMessageType = typename NthFiber<1>::OuterMessageType;
 	using InnerMessageType = typename NthFiber<sizeof...(Fibers)>::InnerMessageType;


### PR DESCRIPTION
- Mostly zero overhead from what I can tell (caveat: the unique identity rule can cause non-zero memory overhead, in turn affecting perf)
- Fibers are equivalent to transports
- A fabric stores all fibers inside and drives them to completion
- Fabrics and fibers can be nested and composed freely, unlike current transports
- Do not need the transport factory equivalents, hence much simpler to write new fibers
- Avoids shredding memory by laying out all memory of a fabric linearly unlike current code where each transport has its memory disjoint with other transports
- Avoids indirections through simple pointer offset calculations (warning: might be brittle), much more cache friendly